### PR TITLE
Removed moment instead use plain Date functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const { createTransform } = require('redux-persist');
 
 /**
@@ -16,7 +15,7 @@ const transformPersistence = (inboundState, config) => {
   // the record is not updated for some time
   if (config.autoExpire && !inboundState[config.persistedAtKey]) {
     inboundState = Object.assign({}, inboundState, {
-      [config.persistedAtKey]: moment()
+      [config.persistedAtKey]: new Date().getTime()
     });
   }
 
@@ -34,11 +33,11 @@ const transformRehydrate = (outboundState, config) => {
 
   // Check for the possible expiry if state has the persisted date
   if (config.expireSeconds && outboundState[config.persistedAtKey]) {
-    const startTime = moment(outboundState[config.persistedAtKey]);
-    const endTime = moment();
+    const startTime = new Date(outboundState[config.persistedAtKey]).getTime();
+    const endTime = new Date().getTime();
 
-    const duration = moment.duration(endTime.diff(startTime));
-    const seconds = duration.asSeconds();
+    const duration = endTime - startTime;
+    const seconds = duration / 1000;
 
     // If the state is older than the set expiry time,
     // reset it to initial state

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "istanbul cover node_modules/mocha/bin/_mocha && codecov"
   },
   "dependencies": {
-    "moment": "^2.24.0",
     "redux": "^4.0.1",
     "redux-persist": "^5.10.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const moment = require('moment');
 const expireReducer = require('../index');
 
 describe('redux-persist-expire', function () {
@@ -23,7 +22,7 @@ describe('redux-persist-expire', function () {
     const reducerKey = 'someReducer';
 
     const transform = expireReducer(reducerKey, { autoExpire: true });
-    const inboundDate = moment().valueOf();
+    const inboundDate = new Date().getTime();
     const inboundOutputState = transform.in(state, reducerKey);
     const persistedDate = inboundOutputState.__persisted_at;
 
@@ -41,9 +40,9 @@ describe('redux-persist-expire', function () {
     const reducerKey = 'someReducer';
 
     const transform = expireReducer(reducerKey, { autoExpire: true, persistedAtKey: 'updatedAt' });
-    const inboundDate = moment().valueOf();
+    const inboundDate = new Date().getTime();
     const inboundOutputState = transform.in(state, reducerKey);
-    const persistedDate = inboundOutputState.updatedAt.valueOf();
+    const persistedDate = inboundOutputState.updatedAt;
 
     // Check if it has the same keys and the updatedAt key
     // Check if the updatedAt has the correct current value
@@ -59,9 +58,9 @@ describe('redux-persist-expire', function () {
     const reducerKey = 'someReducer';
 
     const transform = expireReducer(reducerKey, { autoExpire: true, persistedAtKey: 'updatedAt' });
-    const inboundDate = moment().valueOf();
+    const inboundDate = new Date().getTime();
     const inboundOutputState = transform.in({ username: 'redux3', id: 13 }, reducerKey);
-    const persistedDate = inboundOutputState.updatedAt.valueOf();
+    const persistedDate = inboundOutputState.updatedAt;
 
     // Check if it has the same keys and the updatedAt key
     // Check if the updatedAt has the correct current value
@@ -72,7 +71,7 @@ describe('redux-persist-expire', function () {
 
     // Update the state and date value should still be same
     const inboundOutputState2 = transform.in({ username: 'redux35', id: 133 }, reducerKey);
-    const persistedDate2 = inboundOutputState2.updatedAt.valueOf();
+    const persistedDate2 = inboundOutputState2.updatedAt;
 
     assert.deepEqual(Object.keys(inboundOutputState2), ['username', 'id', 'updatedAt']);
     assert.equal(inboundOutputState2.username, 'redux35');
@@ -84,7 +83,7 @@ describe('redux-persist-expire', function () {
 
   it('can expire the state after expireSeconds have passed', function (done) {
     // Use the old date so that it gets reset
-    const state = { username: 'redux', id: 1, updatedAt: moment().subtract(1, 'seconds') };
+    const state = { username: 'redux', id: 1, updatedAt: new Date(Date.now() - 1 * 1000) };
     const reducerKey = 'someReducer';
 
     const transform = expireReducer(reducerKey, { persistedAtKey: 'updatedAt', expireSeconds: 5 });
@@ -95,7 +94,7 @@ describe('redux-persist-expire', function () {
     const outboundOutputState1 = transform.out(state, reducerKey);
     assert.deepEqual(outboundOutputState1, state, '`out` does not reset the state before time has passed');
 
-    state.updatedAt = moment().subtract(10, 'seconds');
+    state.updatedAt = new Date(Date.now() - 10 * 1000)
 
     const outboundOutputState2 = transform.out(state, reducerKey);
     assert.deepEqual(outboundOutputState2, {}, '`out` resets the state after time has passed');
@@ -108,7 +107,7 @@ describe('redux-persist-expire', function () {
     const state = {
       username: 'redux',
       id: 1,
-      updatedAt: moment().subtract(1, 'seconds')
+      updatedAt: new Date(Date.now() - 1 * 1000)
     };
 
     const reducerKey = 'someReducer';
@@ -126,7 +125,7 @@ describe('redux-persist-expire', function () {
     const outboundOutputState1 = transform.out(state, reducerKey);
     assert.deepEqual(outboundOutputState1, state, '`out` does not reset the state before time has passed');
 
-    state.updatedAt = moment().subtract(1, 'minute');
+    state.updatedAt = new Date(Date.now() - 60 * 1000)
 
     const outboundOutputState2 = transform.out(state, reducerKey);
     assert.deepEqual(outboundOutputState2, { username: 'initial' }, '`out` resets the state after time has passed');

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,11 +492,6 @@ mocha@^5.2.0:
     mkdirp "0.5.1"
     supports-color "5.4.0"
 
-moment@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
As stated here: https://github.com/kamranahmedse/redux-persist-expire/issues/2
The library is heavy in size (around 248 kb) due to the moment of library dependency.

This PR removes the moment dependency and instead uses native Date functions.

What do you think about this approach? any downsides of having plain Date functions?
I think the moment is great but for the use that is done for this package (simple calculations) is not worth the bundle size.

Some folks pointed to use https://date-fns.org/ instead of moment, for sure this will decrease the size, but not sure if needed anyway.

Here are the tests passing:

<img width="1080" alt="Screen Shot 2019-05-21 at 1 36 01 PM" src="https://user-images.githubusercontent.com/466105/58118062-15c19b80-7bce-11e9-9923-235ff7952e56.png">
